### PR TITLE
Remove -MD from the CFLAGS in Makefile.defs to not clutter root direc…

### DIFF
--- a/msp432/Makefile.defs
+++ b/msp432/Makefile.defs
@@ -58,7 +58,6 @@ CFLAGS=-mthumb             \
        ${FPU}              \
        -ffunction-sections \
        -fdata-sections     \
-       -MD                 \
        -std=gnu99            \
        -Dgcc               \
        -D${DEVICE}           \


### PR DESCRIPTION
…tory.

The CFLAGS added the generation of dependency files for all invocations of CC.
In the case of gneerating the qstring database, this led to superfluous .d files
in the platform root directory. Dependency files (.P) are added to the build target
directory later and are correctly included by py.mk, so there is no need to do
anything else.
